### PR TITLE
Allowed multiline CriticMarkup

### DIFF
--- a/cm-mode.el
+++ b/cm-mode.el
@@ -114,19 +114,19 @@ The value is actually a list consisting of the text and a flag
 indicating whether the deletion was done with the backspace
 key.")
 
-(defvar cm-addition-regexp "\\(?:{\\+\\+\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\)*?\\)\\+\\+}\\)"
+(defvar cm-addition-regexp "\\(?:{\\+\\+\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\|[[:space:]]\\)*?\\)\\+\\+}\\)"
   "CriticMarkup addition regexp.")
 
-(defvar cm-deletion-regexp "\\(?:{--\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\)*?\\)--}\\)"
+(defvar cm-deletion-regexp "\\(?:{--\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\|[[:space:]]\\)*?\\)--}\\)"
   "CriticMarkup deletion regexp.")
 
-(defvar cm-substitution-regexp "\\(?:{~~\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\)*?\\)~>\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\)*?\\)~~}\\)"
+(defvar cm-substitution-regexp "\\(?:{~~\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\|[[:space:]]\\)*?\\)~>\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\)*?\\)~~}\\)"
   "CriticMarkup substitution regexp.")
 
-(defvar cm-comment-regexp "\\(?:{>>\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\)*?\\)<<}\\)"
+(defvar cm-comment-regexp "\\(?:{>>\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\|[[:space:]]\\)*?\\)<<}\\)"
   "CriticMarkup comment regexp.")
 
-(defvar cm-highlight-regexp "\\(?:{==\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\)*?\\)==}\\)"
+(defvar cm-highlight-regexp "\\(?:{==\\(\\(?:[[:ascii:]]\\|[[:nonascii:]]\\|[[:space:]]\\)*?\\)==}\\)"
   "CriticMarkup highlight regexp.")
 
 (defvar cm-current-markup-overlay nil


### PR DESCRIPTION
The CriticMarkup documentation [states](https://github.com/CriticMarkup/CriticMarkup-toolkit) that
linebreaks should be avoided, but seems to permit them; also the parser seems to process them well.  (In my opinion, the part on inline elements probably refers to avoiding paragraph breaks, or something causing the insertion of line breaking HTML elements.)

For people who are willing to take the risk, it would be nice to highlight multiline CriticMarkup, which is what these changes do.